### PR TITLE
Replace git pathspec with glob

### DIFF
--- a/.yactrc.toml
+++ b/.yactrc.toml
@@ -1,12 +1,7 @@
 [[items]]
-pathspec = "**/*.rs"
+glob = "**/*.rs"
 transformers = [{External = "Rustfmt"}]
 
 [[items]]
-pathspec = "**/*.md"
+glob = "**/*.md"
 transformers = [{External = "DenoFmt"}]
-
-[[items]]
-pathspec = "*.md"
-transformers = [{External = "DenoFmt"}]
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ strip = true
 [dependencies]
 clap = { version = "4.5.16", features = ["derive"], optional = true }
 git2 = { version = "0.19", default-features = false }
+glob = "0.3.1"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8.19"
 

--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ management tools (like `pre-commit`).
 ```toml
 # Example .yactrc.toml
 items = [
-    { pathspec = "**/*.rs", transformers = [ {External = "Rustfmt"} ]},
-    { pathspec = "**/*.md", transformers = [ {Builtin = "TrailingWhitespace" }]},
-    { pathspec = "*.md", transformers = [ {Builtin = "TrailingWhitespace"} ]}
+    { glob = "**/*.rs", transformers = [ {External = "Rustfmt"} ]},
+    { glob = "**/*.md", transformers = [ {Builtin = "TrailingWhitespace" }]},
+    { glob = "*.md", transformers = [ {Builtin = "TrailingWhitespace"} ]}
 ]
 ```
 
@@ -49,12 +49,6 @@ items = [
 
 yact
 ```
-
-> Note on pathspecs: at the present time, `pathspec` defined in the above items
-> is a git pathspec, which differs subtly from shell globs. Importantly, `**`
-> matches one or more directories rather than zero or more. Because of this, two
-> separate rules are often required to be defined to match all the files of one
-> filetype. This behavior may change in the future.
 
 ## Transformers
 
@@ -85,7 +79,7 @@ and args can be configured. Example below.
 
 ```toml
 [[items]]
-pathspec = "**/*.rs"
+glob = "**/*.rs"
 transformers = [ { System = { command = "rustfmt", env = {}, args = ["--emit", "stdout"] }}]
 ```
 

--- a/src/bin/yact.rs
+++ b/src/bin/yact.rs
@@ -44,6 +44,10 @@ pub fn main() -> ExitCode {
             eprintln!("Could not resolve .yactrc.toml configuration file. Ensure it is located at the root of the repository");
             ExitCode::FAILURE
         }
+        Err(Error::InvalidGlob(glob)) => {
+            eprintln!("Invalid glob found in configuration: '{}'", glob);
+            ExitCode::FAILURE
+        }
         Ok(_) => ExitCode::SUCCESS,
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,7 +30,7 @@ impl TransformerOptions {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ConfigurationItem {
-    pub pathspec: String,
+    pub glob: String,
     pub transformers: Vec<TransformerOptions>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 use git2::{
     build::{CheckoutBuilder, TreeUpdateBuilder},
-    MergeOptions, Pathspec, Repository, Tree, TreeWalkMode, TreeWalkResult,
+    MergeOptions, Repository, Tree, TreeWalkMode, TreeWalkResult,
 };
+use glob::{MatchOptions, Pattern};
 use std::path::Path;
 
 mod builtin_transformers;
@@ -21,6 +22,7 @@ pub enum Error {
     ConfigurationNotFound,
     ConfigurationParseError(toml::de::Error),
     ConfigurationEncodingError(std::str::Utf8Error),
+    InvalidGlob(String),
     RepositoryIsBare,
 
     /// An error was returned from `libgit2`.
@@ -95,8 +97,14 @@ pub fn load_configuration(repository: &Repository) -> Result<Configuration, Erro
     let file =
         std::fs::read(path.join(".yactrc.toml")).map_err(|_| Error::ConfigurationNotFound)?;
     let config_str = std::str::from_utf8(&file)?;
+    let configuration: Configuration = toml::from_str(config_str)?;
+    for item in &configuration.items {
+        if Pattern::new(&item.glob).is_err() {
+            return Err(Error::InvalidGlob(item.glob.clone()));
+        }
+    }
 
-    Ok(toml::from_str(config_str)?)
+    Ok(configuration)
 }
 
 pub fn pre_commit<P: AsRef<Path>>(path: P) -> Result<(), Error> {
@@ -113,12 +121,15 @@ pub fn pre_commit<P: AsRef<Path>>(path: P) -> Result<(), Error> {
     for entry in diff.deltas() {
         if !entry.new_file().is_binary() {
             let matching_config_item = configuration.items.iter().find(|config_item| {
-                Pathspec::new([&config_item.pathspec])
-                    .unwrap()
-                    .matches_path(
-                        entry.new_file().path().unwrap(),
-                        git2::PathspecFlags::DEFAULT,
-                    )
+                let pattern = Pattern::new(&config_item.glob).unwrap();
+                pattern.matches_path_with(
+                    entry.new_file().path().unwrap(),
+                    MatchOptions {
+                        case_sensitive: true,
+                        require_literal_separator: true,
+                        require_literal_leading_dot: true,
+                    },
+                )
             });
             if matching_config_item.is_none() {
                 continue;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -11,7 +11,7 @@ use super::pre_commit;
 fn config() -> Configuration {
     Configuration {
         items: vec![ConfigurationItem {
-            pathspec: "*.md".to_string(),
+            glob: "*.md".to_string(),
             transformers: vec![TransformerOptions::Builtin(
                 BuiltinTransformer::TrailingWhitespace,
             )],


### PR DESCRIPTION
Using git pathspecs to match files proved to be inconvenient, as ** is interpreted as one or more directories instead of zero or more. Use the glob crate instead to provide pattern matching.