### PR TITLE
Add option to require yact to meet a version requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yact"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -14,9 +14,10 @@ lto = true
 strip = true
 
 [dependencies]
-clap = { version = "4.5.16", features = ["derive"], optional = true }
+clap = { version = "4.5.16", features = ["derive", "cargo"], optional = true }
 git2 = { version = "0.19", default-features = false }
 glob = "0.3.1"
+semver = { version = "1.0.24", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 toml = "0.8.19"
 

--- a/src/bin/yact.rs
+++ b/src/bin/yact.rs
@@ -18,7 +18,8 @@
  */
 use std::{path::PathBuf, process::ExitCode};
 
-use clap::Parser;
+use clap::{crate_version, Parser};
+use semver::Version;
 use yact::{pre_commit, Error};
 
 #[derive(Parser)]
@@ -30,7 +31,9 @@ pub struct Args {
 
 pub fn main() -> ExitCode {
     let args = Args::parse();
-    match pre_commit(args.path.unwrap_or(PathBuf::from("."))) {
+    let version = Version::parse(crate_version!()).ok();
+
+    match pre_commit(args.path.unwrap_or(PathBuf::from(".")), version) {
         Err(Error::EmptyIndex) => {
             eprintln!("Aborting commit. No staged changes or they were formatted away.");
             ExitCode::FAILURE
@@ -44,6 +47,10 @@ pub fn main() -> ExitCode {
         }
         Err(Error::RepositoryNotFound) => {
             eprintln!("Repository not found in current or parent directories. yact must be run from within a git repository.");
+            ExitCode::FAILURE
+        }
+        Err(Error::InvalidYactVersion(requirement, version)) => {
+            eprintln!("Repository is configured to require yact version {}, but current version is {}. Please install an appropriate version or update the requirement.", requirement, version);
             ExitCode::FAILURE
         }
         Err(Error::GitError(err)) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,6 +22,7 @@ use crate::{
 };
 use git2::Repository;
 use glob::Pattern;
+use semver::VersionReq;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -56,6 +57,7 @@ pub struct ConfigurationItem {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Configuration {
+    pub requires_yact_version: Option<VersionReq>,
     pub items: Vec<ConfigurationItem>,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,12 +18,14 @@
  */
 
 use git2::{ErrorClass, ErrorCode};
+use semver::{Version, VersionReq};
 
 #[derive(Debug)]
 pub enum Error {
     ConfigurationNotFound,
     ConfigurationParseError(toml::de::Error),
     ConfigurationEncodingError(std::str::Utf8Error),
+    InvalidYactVersion(VersionReq, Version),
     InvalidGlob(String),
     RepositoryNotFound,
     RepositoryIsBare,

--- a/src/pre_commit.rs
+++ b/src/pre_commit.rs
@@ -22,6 +22,7 @@ use git2::{
     MergeOptions, Repository, Tree, TreeWalkMode, TreeWalkResult,
 };
 use glob::{MatchOptions, Pattern};
+use semver::Version;
 use std::path::Path;
 
 fn build_worktree_slice<'repo>(
@@ -58,9 +59,21 @@ fn build_worktree_slice<'repo>(
 /// merge results back into worktree.
 ///
 /// This is the core algorithm provided by this project.
-pub fn pre_commit<P: AsRef<Path>>(path: P) -> Result<(), Error> {
+pub fn pre_commit<P: AsRef<Path>>(path: P, check_version: Option<Version>) -> Result<(), Error> {
     let repository = Repository::discover(path)?;
     let configuration = load_configuration(&repository)?;
+
+    if let Some(ref version) = check_version {
+        if let Some(version_requirement) = configuration.requires_yact_version {
+            if !version_requirement.matches(version) {
+                return Err(Error::InvalidYactVersion(
+                    version_requirement.clone(),
+                    version.clone(),
+                ));
+            }
+        }
+    }
+
     let mut index = repository.index()?;
     let index_tree = repository.find_tree(index.write_tree()?)?;
     let last_committed_tree = repository.head()?.peel_to_tree()?;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -28,6 +28,7 @@ use super::pre_commit;
 
 fn config() -> Configuration {
     Configuration {
+        requires_yact_version: None,
         items: vec![ConfigurationItem {
             glob: "*.md".to_string(),
             transformers: vec![TransformerOptions::Builtin(
@@ -81,7 +82,7 @@ fn basic_operation_works() {
     index.add_path(readme_path).unwrap();
     index.write().unwrap();
 
-    let pre_commit_result = pre_commit(repo_path.as_path());
+    let pre_commit_result = pre_commit(repo_path.as_path(), None);
     assert!(matches!(pre_commit_result, Err(crate::Error::EmptyIndex)));
     /*
      * After pre-commit runs, commit the index
@@ -136,7 +137,7 @@ fn conflict_handled_correctly() {
      */
     std::fs::write(repo_path.join("README.md"), "# Blab").unwrap();
 
-    let pre_commit_result = pre_commit(repo_path.as_path());
+    let pre_commit_result = pre_commit(repo_path.as_path(), None);
     assert!(matches!(pre_commit_result, Err(crate::Error::EmptyIndex)));
 
     /*

--- a/yactrc.toml
+++ b/yactrc.toml
@@ -1,7 +1,9 @@
+requires_yact_version = ">=1.0.0, <2.0.0"
+
 [[items]]
 glob = "**/*.rs"
-transformers = [{External = "Rustfmt"}]
+transformers = [{ External = "Rustfmt" }]
 
 [[items]]
 glob = "**/*.md"
-transformers = [{External = "DenoFmt"}]
+transformers = [{ External = "DenoFmt" }]


### PR DESCRIPTION
Add an optional field `require_yact_version` that takes a `semver::VersionReq` to the yactrc.toml. Then if provided, ensure that the running yact version matches this version requirement.