### PR TITLE
Support package manager isolation for common formatters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yact"
-version = "1.1.0"
+version = "2.0.0"
 edition = "2021"
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yact"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -33,22 +33,64 @@ management tools (like `pre-commit`).
 
 ## Usage
 
-1. Create a config file named `yactrc.toml` in the workspace root.
+1. Create a config file named `yactrc.toml` in the workspace root. Below are
+   some example config files that will apply to most people. Note that the
+   configuration file is dependent on what languages and formatters your team
+   prefers, so these may require modification.
 
 ```toml
-# Example yactrc.toml
+# Example yactrc.toml for Rust programmers
+[[items]]
+glob = "**/*.rs"
+transformers = [{ External = "Rustfmt" }]
+
+[[items]]
+glob = "**/*.md"
+transformers = [{ Builtin = "TrailingWhitespace" }]
+```
+
+```toml
+# Example yactrc.toml for C / C++ programmers
 items = [
-    { glob = "**/*.rs", transformers = [{External = "Rustfmt"}] },
-    { glob = "**/*.md", transformers = [{External = "DenoFmt" }] },
     { glob = "**/*.cpp", transformers = [{External = "ClangFormat"}] },
     { glob = "**/*.hpp", transformers = [{External = "ClangFormat"}] },
     { glob = "**/*.h", transformers = [{External = "ClangFormat"}] },
     { glob = "**/*.c", transformers = [{External = "ClangFormat"}] },
-    { glob = "**/*.js", transformers = [{External = "Prettier"}] },
-    { glob = "**/*.ts", transformers = [{External = "Prettier"}] },
-    { glob = "**/*.py", transformers = [{External = "RuffFormat"}] },
-    { glob = "**/*.pyi", transformers = [{External = "RuffFormat"}] },
-    { glob = "**/*.txt", transformers = [{Builtin = "TrailingWhitespace"}] },
+
+    # clang-format also works for Javascript and JSON. If it's already
+    # installed, may as well use it rather than configuring a different tool.
+    { glob = "**/*.js", transformers = [{External = "ClangFormat"}] },
+    { glob = "**/*.json", transformers = [{External = "ClangFormat"}] },
+   
+    { glob = "**/*.md", transformers = [{ Builtin = "TrailingWhitespace" }]},
+]
+```
+
+```toml
+# Example yactrc.toml for web developers
+# "Npm" can be replaced with "Yarn", or the field can be removed entirely to
+# use a global installation of prettier.
+items = [
+    { glob = "**/*.js", transformers = [{External = { Prettier = { package_manager_type = "Npm" } }}] },
+    { glob = "**/*.ts", transformers = [{External = { Prettier = { package_manager_type = "Npm" }}}] },
+    { glob = "**/*.jsx", transformers = [{External = { Prettier = { package_manager_type = "Npm" }}}] },
+    { glob = "**/*.tsx", transformers = [{External = { Prettier = { package_manager_type = "Npm" }}}] },
+    { glob = "**/*.html", transformers = [{External = { Prettier = { package_manager_type = "Npm" }}}] },
+    { glob = "**/*.json", transformers = [{External = { Prettier = { package_manager_type = "Npm" }}}] },
+    { glob = "**/*.md", transformers = [{External = { Prettier = { package_manager_type = "Npm" }}}] },
+]
+```
+
+```toml
+# Example yactrc.toml for Python programmers
+# To use a virtual environment, run `git commit` from the activated environment
+# or provide the virtual environment path (recommended to be within repository
+# root), for example `{ RuffFormat = { venv_path = ".venv" }}`
+items = [
+    { glob = "**/*.py", transformers = [{ External = { RuffFormat = {}}}] },
+    { glob = "**/*.pyi", transformers = [{ External = { RuffFormat = {}}}] },
+
+    { glob = "**/*.md", transformers = [{ Builtin = "TrailingWhitespace" }]},
 ]
 ```
 

--- a/src/bin/yact.rs
+++ b/src/bin/yact.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023, 2024 Nelson Penn
+ * Copyright 2023, 2024, 2025 Nelson Penn
  *
  * This file is part of Yet Another Commit Transformer.
  *
@@ -55,6 +55,10 @@ pub fn main() -> ExitCode {
         }
         Err(Error::GitError(err)) => {
             eprintln!("Unexpected git error: {}", err);
+            ExitCode::FAILURE
+        }
+        Err(Error::IoError(err)) => {
+            eprintln!("Unexpected IO error: {}", err);
             ExitCode::FAILURE
         }
         Err(Error::ConfigurationParseError(err)) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,9 +40,7 @@ impl TransformerOptions {
             Self::External(command_type) => {
                 let command_type = command_type.clone();
                 Box::new(create_shell_transformer(move |extension: Option<&str>| {
-                    let mut command = std::process::Command::new(command_type.command_str());
-                    command_type.configure_command(&mut command, extension);
-                    command
+                    command_type.get_command(extension)
                 }))
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023, 2024 Nelson Penn
+ * Copyright 2023, 2024, 2025 Nelson Penn
  *
  * This file is part of Yet Another Commit Transformer.
  *
@@ -24,6 +24,7 @@ use git2::Repository;
 use glob::Pattern;
 use semver::VersionReq;
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum TransformerOptions {
@@ -32,15 +33,16 @@ pub enum TransformerOptions {
 }
 
 impl TransformerOptions {
-    pub fn transformer(&self) -> Box<dyn Transformer> {
+    pub fn transformer(&self, repository_path: &Path) -> Box<dyn Transformer> {
         match self {
             Self::Builtin(BuiltinTransformer::TrailingWhitespace) => {
                 Box::new(builtin_transformers::trailing_whitespace)
             }
             Self::External(command_type) => {
                 let command_type = command_type.clone();
+                let repository_path = repository_path.to_path_buf();
                 Box::new(create_shell_transformer(move |extension: Option<&str>| {
-                    command_type.get_command(extension)
+                    command_type.get_command(&repository_path, extension)
                 }))
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023, 2024 Nelson Penn
+ * Copyright 2023, 2024, 2025 Nelson Penn
  *
  * This file is part of Yet Another Commit Transformer.
  *
@@ -36,6 +36,9 @@ pub enum Error {
     /// One of the transformers encountered an error.
     TransformerError(String),
 
+    /// Unexpected std::io::Error
+    IoError(std::io::Error),
+
     /// No other errors, but the resulting index was empty.
     ///
     /// The commit should be aborted.
@@ -57,6 +60,12 @@ impl From<git2::Error> for Error {
         } else {
             Self::GitError(err)
         }
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(value: std::io::Error) -> Self {
+        Self::IoError(value)
     }
 }
 

--- a/src/external_transformers.rs
+++ b/src/external_transformers.rs
@@ -17,7 +17,14 @@
  * Yet Another Commit Transformer. If not, see <https://www.gnu.org/licenses/>.
  */
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf, process::Command};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum JavascriptPackageManagerType {
+    Node,
+    Yarn,
+    YarnPlugNPlay,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ShellCommandTransformer {
@@ -29,54 +36,78 @@ pub enum ShellCommandTransformer {
         args: Vec<String>,
     },
     DenoFmt,
-    Prettier,
-    RuffFormat,
+    Prettier {
+        package_manager_type: Option<JavascriptPackageManagerType>,
+    },
+    RuffFormat {
+        venv_path: Option<PathBuf>,
+    },
 }
 
 impl ShellCommandTransformer {
-    pub fn command_str(&self) -> &str {
-        match self {
-            Self::Rustfmt => "rustfmt",
-            Self::ClangFormat => "clang-format",
-            Self::System { command, .. } => command.as_str(),
-            Self::DenoFmt => "deno",
-            Self::Prettier => "prettier",
-            Self::RuffFormat => "ruff",
-        }
-    }
-
-    pub fn configure_command(&self, command: &mut std::process::Command, extension: Option<&str>) {
+    pub fn get_command(&self, extension: Option<&str>) -> Command {
+        /*
+         * TODO: paths should be relative to repository root, need repository
+         * root path to configure command.
+         */
         match self {
             Self::Rustfmt => {
+                let mut command = Command::new("rustfmt");
                 command.args(["--emit", "stdout"]);
-            }
-            Self::System { env, args, .. } => {
-                command.envs(env);
-                command.args(args);
+                command
             }
             Self::ClangFormat => {
+                let mut command = Command::new("clang-format");
                 if let Some(extension) = extension {
                     command.args(["--assume-filename", &format!("example.{}", extension)]);
                 }
+                command
+            }
+            Self::System { command, env, args } => {
+                let mut command = Command::new(command);
+                command.envs(env);
+                command.args(args);
+                command
             }
             Self::DenoFmt => {
+                let mut command = Command::new("deno");
                 command.arg("fmt");
                 if let Some(extension) = extension {
                     command.args(["--ext", extension]);
                 }
                 command.arg("-");
+                command
             }
-            Self::Prettier => {
+            Self::Prettier {
+                package_manager_type,
+            } => {
+                let mut command = match package_manager_type {
+                    Some(JavascriptPackageManagerType::Node)
+                    | Some(JavascriptPackageManagerType::Yarn) => todo!(),
+                    Some(JavascriptPackageManagerType::YarnPlugNPlay) => todo!(),
+                    None => Command::new("prettier"),
+                };
                 if let Some(extension) = extension {
                     command.args(["--stdin-filepath", &format!("example.{}", extension)]);
                 }
+                command
             }
-            Self::RuffFormat => {
+            Self::RuffFormat { venv_path } => {
+                let mut command = match venv_path {
+                    Some(path) => {
+                        let python_path = path.join("bin").join("python");
+                        let mut command = Command::new(python_path);
+                        command.args(["-m", "ruff"]);
+                        command
+                    }
+                    None => Command::new("ruff"),
+                };
                 command.arg("format");
                 if let Some(extension) = extension {
                     command.args(["--stdin-filename", &format!("example.{}", extension)]);
                 }
                 command.args(["--quiet", "-"]);
+                command
             }
         }
     }

--- a/src/external_transformers.rs
+++ b/src/external_transformers.rs
@@ -88,7 +88,12 @@ impl ShellCommandTransformer {
                     }
                     Some(JavascriptPackageManagerType::Yarn) => {
                         let mut command = Command::new("yarn");
-                        command.args(["run", "prettier"]);
+                        /*
+                         * "silent" option is required because otherwise yarn
+                         * will print to stdout, ultimately ending up in the
+                         * formatted file contents.
+                         */
+                        command.args(["run", "-s", "prettier"]);
                         command
                     }
                     None => Command::new("prettier"),

--- a/src/external_transformers.rs
+++ b/src/external_transformers.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023, 2024 Nelson Penn
+ * Copyright 2023, 2024, 2025 Nelson Penn
  *
  * This file is part of Yet Another Commit Transformer.
  *
@@ -17,7 +17,11 @@
  * Yet Another Commit Transformer. If not, see <https://www.gnu.org/licenses/>.
  */
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, path::PathBuf, process::Command};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum JavascriptPackageManagerType {
@@ -44,7 +48,11 @@ pub enum ShellCommandTransformer {
 }
 
 impl ShellCommandTransformer {
-    pub fn get_command(&self, extension: Option<&str>) -> Command {
+    pub fn get_command<P: AsRef<Path>>(
+        &self,
+        repository_path: P,
+        extension: Option<&str>,
+    ) -> Command {
         /*
          * TODO: paths should be relative to repository root, need repository
          * root path to configure command.
@@ -105,8 +113,17 @@ impl ShellCommandTransformer {
             }
             Self::RuffFormat { venv_path } => {
                 let mut command = match venv_path {
-                    Some(path) => {
-                        let python_path = path.join("bin").join("python");
+                    Some(venv_path) => {
+                        /*
+                         * This works even if path is absolute as join will
+                         * replace the original path with the absolute one.
+                         */
+                        let python_path = repository_path
+                            .as_ref()
+                            .join(venv_path)
+                            .join("bin")
+                            .join("python");
+
                         let mut command = Command::new(python_path);
                         command.args(["-m", "ruff"]);
                         command

--- a/src/external_transformers.rs
+++ b/src/external_transformers.rs
@@ -23,7 +23,6 @@ use std::{collections::HashMap, path::PathBuf, process::Command};
 pub enum JavascriptPackageManagerType {
     Node,
     Yarn,
-    YarnPlugNPlay,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -82,9 +81,16 @@ impl ShellCommandTransformer {
                 package_manager_type,
             } => {
                 let mut command = match package_manager_type {
-                    Some(JavascriptPackageManagerType::Node)
-                    | Some(JavascriptPackageManagerType::Yarn) => todo!(),
-                    Some(JavascriptPackageManagerType::YarnPlugNPlay) => todo!(),
+                    Some(JavascriptPackageManagerType::Node) => {
+                        let mut command = Command::new("npx");
+                        command.arg("prettier");
+                        command
+                    }
+                    Some(JavascriptPackageManagerType::Yarn) => {
+                        let mut command = Command::new("yarn");
+                        command.args(["run", "prettier"]);
+                        command
+                    }
                     None => Command::new("prettier"),
                 };
                 if let Some(extension) = extension {

--- a/src/external_transformers.rs
+++ b/src/external_transformers.rs
@@ -25,7 +25,7 @@ use std::{
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum JavascriptPackageManagerType {
-    Node,
+    Npm,
     Yarn,
 }
 
@@ -89,7 +89,7 @@ impl ShellCommandTransformer {
                 package_manager_type,
             } => {
                 let mut command = match package_manager_type {
-                    Some(JavascriptPackageManagerType::Node) => {
+                    Some(JavascriptPackageManagerType::Npm) => {
                         let mut command = Command::new("npx");
                         command.arg("prettier");
                         command

--- a/src/pre_commit.rs
+++ b/src/pre_commit.rs
@@ -62,6 +62,7 @@ fn build_worktree_slice<'repo>(
 pub fn pre_commit<P: AsRef<Path>>(path: P, check_version: Option<Version>) -> Result<(), Error> {
     let repository = Repository::discover(path)?;
     let repository_path = repository.workdir().ok_or(Error::RepositoryIsBare)?;
+    std::env::set_current_dir(repository_path)?;
     let configuration = load_configuration(&repository)?;
 
     if let Some(ref version) = check_version {

--- a/src/pre_commit.rs
+++ b/src/pre_commit.rs
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023, 2024 Nelson Penn
+ * Copyright 2023, 2024, 2025 Nelson Penn
  *
  * This file is part of Yet Another Commit Transformer.
  *
@@ -61,6 +61,7 @@ fn build_worktree_slice<'repo>(
 /// This is the core algorithm provided by this project.
 pub fn pre_commit<P: AsRef<Path>>(path: P, check_version: Option<Version>) -> Result<(), Error> {
     let repository = Repository::discover(path)?;
+    let repository_path = repository.workdir().ok_or(Error::RepositoryIsBare)?;
     let configuration = load_configuration(&repository)?;
 
     if let Some(ref version) = check_version {
@@ -102,7 +103,7 @@ pub fn pre_commit<P: AsRef<Path>>(path: P, check_version: Option<Version>) -> Re
                 .unwrap()
                 .transformers
                 .iter()
-                .map(|x| x.transformer())
+                .map(|x| x.transformer(repository_path))
                 .collect::<Vec<_>>();
 
             eprintln!(


### PR DESCRIPTION
Support:

- Running `ruff` from in-repository Python virtual environment
- Running `prettier` via locally installed version from `npm` or `yarn`